### PR TITLE
Fix readme for Part 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ npm install
 $ cp node_modules/angular/angular.* public/js/
 $ cp node_modules/angular-route/angular-route.* public/js/
 $ cp node_modules/angular-resource/angular-resource.* public/js/
+$ cp node_modules/angular-loading-bar/build/loading-bar.* public/lib/
 # run server
 $ npm start
 ```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "angular": "^1.3.15",
     "angular-resource": "^1.3.15",
     "angular-route": "^1.3.15",
+    "angular-loading-bar": "*",
     "body-parser": "~1.12.0",
     "cookie-parser": "~1.3.4",
     "debug": "~2.1.1",


### PR DESCRIPTION
The README file (and packaging descriptor) don't provide enough info to install Part 5 version
